### PR TITLE
test: add unit tests for reviews and transform

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "LICENSE"
   ],
   "scripts": {
-    "test": "node --test tests/unit/*.test.js tests/integration/*.test.js",
-    "test:unit": "node --test tests/unit/*.test.js",
+    "test": "node --experimental-test-module-mocks --test tests/unit/*.test.js tests/integration/*.test.js",
+    "test:unit": "node --experimental-test-module-mocks --test tests/unit/*.test.js",
     "test:integration": "node --test tests/integration/*.test.js",
     "smoke": "node ./scripts/smoke.js",
     "lint": "eslint .",

--- a/tests/unit/reviews.test.js
+++ b/tests/unit/reviews.test.js
@@ -1,0 +1,131 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+const reviewFixtures = {
+  "male-review": {
+    anonymous: false,
+    buyerName: "John",
+    buyerGender: "M",
+    buyerCountry: "US",
+    buyerEval: 100,
+    skuInfo: "Color: Red",
+    evalDate: "2024-01-01",
+    buyerFeedback: "Great product",
+    images: ["img1.jpg"],
+    thumbnails: ["thumb1.jpg"],
+  },
+  "female-review": {
+    anonymous: true,
+    buyerGender: "F",
+    buyerCountry: "GB",
+    buyerEval: 80,
+    skuInfo: "Size: M",
+    evalDate: "2024-02-01",
+    buyerFeedback: "Good quality",
+  },
+  "no-eval": {
+    anonymous: false,
+    buyerGender: "M",
+    buyerCountry: "DE",
+    skuInfo: "",
+    evalDate: "2024-03-01",
+    buyerFeedback: "OK",
+  },
+  "no-name": {
+    anonymous: false,
+    buyerGender: "M",
+    buyerCountry: "US",
+    buyerEval: 60,
+    skuInfo: "",
+    evalDate: "2024-04-01",
+    buyerFeedback: "Decent",
+  },
+  "named-buyer": {
+    anonymous: false,
+    buyerName: "Alice Smith",
+    buyerGender: "F",
+    buyerCountry: "FR",
+    buyerEval: 100,
+    skuInfo: "",
+    evalDate: "2024-05-01",
+    buyerFeedback: "Excellent",
+  },
+};
+
+// Map productId to which fixture(s) to return
+const productIdToFixtures = {
+  "1": [reviewFixtures["male-review"]],
+  "2": [reviewFixtures["female-review"]],
+  "3": [reviewFixtures["no-eval"]],
+  "4": [reviewFixtures["no-name"]],
+  "5": [reviewFixtures["named-buyer"]],
+  "6": [], // empty
+};
+
+test("reviews module", async (t) => {
+  t.mock.module("node-fetch", {
+    defaultExport: async (url) => {
+      const match = url.match(/productId=(\d+)/);
+      const productId = match ? match[1] : null;
+      const fixtures = productIdToFixtures[productId] || [];
+      return {
+        ok: true,
+        json: async () => ({ data: { evaViewList: fixtures } }),
+      };
+    },
+  });
+
+  const { get } = await import("../../src/reviews.js");
+
+  await t.test("male gender mapping and rating calculation", async () => {
+    const result = await get({ productId: "1", total: 1, limit: 1 });
+
+    assert.equal(result.length, 1);
+    assert.equal(result[0].name, "John");
+    assert.equal(result[0].gender, "male");
+    assert.equal(result[0].rating, 5); // 100 / 20
+    assert.equal(result[0].country, "US");
+    assert.equal(result[0].content, "Great product");
+    assert.equal(result[0].info, "Color: Red");
+    assert.deepStrictEqual(result[0].photos, ["img1.jpg"]);
+    assert.deepStrictEqual(result[0].thumbnails, ["thumb1.jpg"]);
+  });
+
+  await t.test("female gender, partial rating, empty photos", async () => {
+    const result = await get({ productId: "2", total: 1, limit: 1 });
+
+    assert.equal(result[0].gender, "female");
+    assert.equal(result[0].rating, 4); // 80 / 20
+    assert.equal(result[0].country, "GB");
+    assert.deepStrictEqual(result[0].photos, []);
+    assert.deepStrictEqual(result[0].thumbnails, []);
+  });
+
+  await t.test("default rating 5 when buyerEval missing", async () => {
+    const result = await get({ productId: "3", total: 1, limit: 1 });
+
+    assert.equal(result[0].rating, 5);
+  });
+
+  await t.test("fallback to faker name when buyerName missing", async () => {
+    const result = await get({ productId: "4", total: 1, limit: 1 });
+
+    // name should equal displayName (faker-generated) since buyerName is absent
+    assert.equal(result[0].name, result[0].displayName);
+    assert.equal(typeof result[0].name, "string");
+    assert.ok(result[0].name.length > 0);
+  });
+
+  await t.test("uses buyerName when provided", async () => {
+    const result = await get({ productId: "5", total: 1, limit: 1 });
+
+    assert.equal(result[0].name, "Alice Smith");
+    assert.equal(typeof result[0].displayName, "string");
+  });
+
+  await t.test("empty response returns empty array", async () => {
+    const result = await get({ productId: "6", total: 20, limit: 20 });
+
+    assert.deepStrictEqual(result, []);
+  });
+});

--- a/tests/unit/transform.test.js
+++ b/tests/unit/transform.test.js
@@ -1,0 +1,130 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildProductJson } from "../../src/transform.js";
+
+test("buildProductJson maps all fields correctly", () => {
+  const data = {
+    productInfoComponent: {
+      subject: "Test Widget",
+      categoryId: 42,
+      id: 12345,
+    },
+    inventoryComponent: {
+      totalQuantity: 100,
+      totalAvailQuantity: 80,
+    },
+    tradeComponent: {
+      formatTradeCount: "500+",
+    },
+    sellerComponent: {
+      storeName: "Best Store",
+      storeLogo: "https://logo.png",
+      companyId: 99,
+      storeNum: 1001,
+      topRatedSeller: true,
+      payPalAccount: false,
+    },
+    storeFeedbackComponent: {
+      sellerPositiveNum: 200,
+      sellerPositiveRate: "98.5",
+    },
+    feedbackComponent: {
+      evarageStar: "4.7",
+      totalValidNum: 150,
+      fiveStarNum: 100,
+      fourStarNum: 30,
+      threeStarNum: 10,
+      twoStarNum: 5,
+      oneStarNum: 5,
+    },
+    imageComponent: {
+      imagePathList: ["img1.jpg", "img2.jpg"],
+    },
+    skuComponent: {
+      productSKUPropertyList: [],
+    },
+    priceComponent: {
+      skuPriceList: [],
+      origPrice: { minAmount: 10, maxAmount: 20 },
+      discountPrice: { minActivityAmount: 8, maxActivityAmount: 16 },
+    },
+    productPropComponent: {
+      props: [{ name: "Material", value: "Cotton" }],
+    },
+    currencyComponent: {
+      currencyCode: "USD",
+    },
+    webGeneralFreightCalculateComponent: {
+      originalLayoutResultList: [],
+    },
+  };
+
+  const result = buildProductJson({
+    data,
+    descriptionData: "<p>Description</p>",
+    reviews: [{ name: "Reviewer" }],
+  });
+
+  assert.equal(result.title, "Test Widget");
+  assert.equal(result.categoryId, 42);
+  assert.equal(result.productId, 12345);
+  assert.deepStrictEqual(result.quantity, { total: 100, available: 80 });
+  assert.equal(result.description, "<p>Description</p>");
+  assert.equal(result.orders, "500+");
+  assert.equal(result.storeInfo.name, "Best Store");
+  assert.equal(result.storeInfo.isTopRated, true);
+  assert.equal(result.storeInfo.ratingCount, 200);
+  assert.equal(result.storeInfo.rating, "98.5");
+  assert.equal(result.ratings.averageStar, "4.7");
+  assert.equal(result.ratings.totalStar, 5);
+  assert.equal(result.ratings.fiveStarCount, 100);
+  assert.deepStrictEqual(result.images, ["img1.jpg", "img2.jpg"]);
+  assert.deepStrictEqual(result.reviews, [{ name: "Reviewer" }]);
+  assert.deepStrictEqual(result.originalPrice, { min: 10, max: 20 });
+  assert.deepStrictEqual(result.salePrice, { min: 8, max: 16 });
+  assert.equal(result.currencyInfo.currencyCode, "USD");
+  assert.deepStrictEqual(result.specs, [{ name: "Material", value: "Cotton" }]);
+});
+
+test("buildProductJson handles empty/missing data gracefully", () => {
+  const result = buildProductJson({ data: {} });
+
+  assert.equal(result.title, undefined);
+  assert.equal(result.categoryId, undefined);
+  assert.equal(result.productId, undefined);
+  assert.deepStrictEqual(result.quantity, { total: 0, available: 0 });
+  assert.equal(result.description, null);
+  assert.equal(result.orders, "0");
+  assert.equal(result.storeInfo.isTopRated, false);
+  assert.equal(result.storeInfo.hasPayPalAccount, false);
+  assert.equal(result.storeInfo.ratingCount, 0);
+  assert.equal(result.storeInfo.rating, "0");
+  assert.equal(result.ratings.averageStar, "0");
+  assert.equal(result.ratings.totalStartCount, 0);
+  assert.deepStrictEqual(result.images, []);
+  assert.deepStrictEqual(result.reviews, []);
+  assert.deepStrictEqual(result.specs, []);
+  assert.deepStrictEqual(result.currencyInfo, {});
+  assert.deepStrictEqual(result.shipping, []);
+});
+
+test("buildProductJson defaults description to null and reviews to []", () => {
+  const result = buildProductJson({ data: {} });
+
+  assert.equal(result.description, null);
+  assert.deepStrictEqual(result.reviews, []);
+});
+
+test("buildProductJson passes through description and reviews", () => {
+  const desc = "<div>Hello</div>";
+  const revs = [{ rating: 5 }, { rating: 4 }];
+
+  const result = buildProductJson({
+    data: {},
+    descriptionData: desc,
+    reviews: revs,
+  });
+
+  assert.equal(result.description, desc);
+  assert.deepStrictEqual(result.reviews, revs);
+});


### PR DESCRIPTION
## Summary
- Added `tests/unit/reviews.test.js` — 6 tests covering the review transform logic via mocked fetch:
  - Male/female gender mapping
  - Rating calculation (buyerEval / 20) and default rating
  - Fallback to faker name when buyerName missing
  - Empty photos/thumbnails default to []
  - Empty response stops pagination
- Added `tests/unit/transform.test.js` — 4 tests covering `buildProductJson()`:
  - Full field mapping from data object
  - Graceful handling of missing/undefined sub-components
  - Default values (quantity 0, orders "0", ratings "0")
  - Description and reviews passthrough
- Enabled `--experimental-test-module-mocks` flag in test scripts for node-fetch mocking

## Test plan
- [x] `pnpm run lint` passes
- [x] `pnpm run test` passes (22 tests total: 11 existing + 10 new + 1 parent)
- [ ] Verify CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)