### PR TITLE
feat: add fastMode option to skip description and reviews

### DIFF
--- a/docs/FEATURE_PROPOSALS.md
+++ b/docs/FEATURE_PROPOSALS.md
@@ -1,0 +1,159 @@
+# Feature Proposals
+
+Detailed specs for the top 3 features on the roadmap. See [PLAN.md](./PLAN.md) for the full milestone overview.
+
+---
+
+## 1. Accept Product URL (not just ID)
+
+**Phase:** 2 (codex/ux-perf)
+**Effort:** Low | **Impact:** High
+
+### Problem
+Users typically copy a full AliExpress URL from their browser. Requiring them to manually extract the numeric product ID is friction-heavy and error-prone.
+
+### Proposed API
+
+```js
+import scrape from "aliexpress-product-scraper";
+
+// Existing — still works
+const product = await scrape("1005006543210");
+
+// New — pass a full URL
+const product = await scrape("https://www.aliexpress.com/item/1005006543210.html");
+```
+
+### Supported URL formats
+
+| Pattern | Example |
+|---|---|
+| `aliexpress.com/item/<id>.html` | `https://www.aliexpress.com/item/1005006543210.html` |
+| `aliexpress.us/item/<id>.html` | `https://aliexpress.us/item/1005006543210.html` |
+| Mobile | `https://m.aliexpress.com/item/1005006543210.html` |
+| With query params | `https://www.aliexpress.com/item/1005006543210.html?spm=abc` |
+
+### Implementation notes
+- Parse the input: if it contains `/item/`, extract the numeric ID via regex.
+- If the input is already numeric (or numeric string), use it directly.
+- Throw a clear error for unrecognized formats.
+
+### Acceptance criteria
+- [ ] `scrape(url)` produces identical output to `scrape(id)` for the same product
+- [ ] All supported URL formats resolve correctly
+- [ ] Invalid URLs throw a descriptive error
+- [ ] Existing numeric ID usage is unaffected (backward compatible)
+- [ ] Unit tests cover URL parsing logic
+
+---
+
+## 2. `fastMode` Option
+
+**Phase:** 2 (codex/ux-perf)
+**Effort:** Medium | **Impact:** High
+
+### Problem
+Many users (especially dropshippers doing quick lookups) only need basic product info — title, price, variants, images. Fetching the full description page and reviews API adds significant time.
+
+### Proposed API
+
+```js
+import scrape from "aliexpress-product-scraper";
+
+const product = await scrape("1005006543210", { fastMode: true });
+
+// product.description === null
+// product.reviews === []
+```
+
+### What changes in fastMode
+
+| Field | Normal | fastMode |
+|---|---|---|
+| `title`, `productId`, `categoryId` | Populated | Populated |
+| `quantity`, `orders` | Populated | Populated |
+| `storeInfo`, `ratings` | Populated | Populated |
+| `images`, `variants`, `specs` | Populated | Populated |
+| `originalPrice`, `salePrice` | Populated | Populated |
+| `currencyInfo`, `shipping` | Populated | Populated |
+| `description` | HTML string | `null` |
+| `reviews` | Array of reviews | `[]` |
+
+### Performance optimizations
+- Skip navigation to description iframe/page
+- Skip review API calls (all pagination)
+- Block heavy resources in Puppeteer (images, fonts, stylesheets) via `page.setRequestInterception`
+- Expected speedup: 50–70%
+
+### Acceptance criteria
+- [ ] `fastMode: true` skips description and review fetching
+- [ ] Output shape is identical (description is `null`, reviews is `[]`)
+- [ ] Resource blocking reduces page load time measurably
+- [ ] Default behavior (`fastMode` unset or `false`) is unchanged
+- [ ] Unit tests verify field presence/absence in fastMode
+
+---
+
+## 3. Batch Scraping with `scrapeMany()`
+
+**Phase:** 3 (codex/feature/batch)
+**Effort:** High | **Impact:** High
+
+### Problem
+Dropshipping users need to scrape dozens or hundreds of products. Calling `scrape()` sequentially is slow, and naively parallelizing it crashes the browser or triggers rate limiting.
+
+### Proposed API
+
+#### Callback style
+
+```js
+import { scrapeMany } from "aliexpress-product-scraper";
+
+const results = await scrapeMany(
+  ["1005006543210", "1005006543211", "1005006543212"],
+  {
+    concurrency: 3,        // max parallel browser tabs (default: 2)
+    retries: 2,            // retries per item on failure (default: 1)
+    timeout: 30000,        // per-item timeout in ms (default: 60000)
+    fastMode: false,       // applies to all items
+    onProgress: ({ completed, total, productId, success }) => {
+      console.log(`${completed}/${total} done`);
+    },
+  }
+);
+
+// results: Array<{ productId, data, error }>
+```
+
+#### Async iterator style
+
+```js
+import { scrapeMany } from "aliexpress-product-scraper";
+
+for await (const result of scrapeMany(ids, { concurrency: 3 })) {
+  if (result.error) {
+    console.error(`Failed: ${result.productId}`, result.error);
+  } else {
+    console.log(`Got: ${result.data.title}`);
+  }
+}
+```
+
+### Design decisions
+- **Browser reuse:** open one browser, use multiple tabs (pages) for concurrency
+- **Concurrency control:** limit active tabs to `concurrency` value
+- **Retries:** per-item retry with exponential backoff
+- **Timeout:** per-item timeout; does not affect other items
+- **Error isolation:** one item's failure does not abort the batch
+- **Return format:** each result includes `{ productId, data, error }` so callers can handle partial failures
+
+### Acceptance criteria
+- [ ] `scrapeMany()` scrapes multiple products concurrently
+- [ ] Concurrency is respected (never exceeds `concurrency` tabs)
+- [ ] Failed items are retried up to `retries` times
+- [ ] Per-item timeout terminates slow scrapes without affecting others
+- [ ] `onProgress` callback fires after each item completes
+- [ ] Async iterator yields results as they complete
+- [ ] Browser is reused across all items and closed after completion
+- [ ] Existing `scrape()` API is unchanged
+- [ ] Integration test with fixtures verifies batch orchestration logic

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "LICENSE"
   ],
   "scripts": {
-    "test": "node --test tests/unit/*.test.js tests/integration/*.test.js",
-    "test:unit": "node --test tests/unit/*.test.js",
+    "test": "node --experimental-test-module-mocks --test tests/unit/*.test.js tests/integration/*.test.js",
+    "test:unit": "node --experimental-test-module-mocks --test tests/unit/*.test.js",
     "test:integration": "node --test tests/integration/*.test.js",
     "smoke": "node ./scripts/smoke.js",
     "lint": "eslint .",

--- a/scripts/smoke.js
+++ b/scripts/smoke.js
@@ -11,35 +11,73 @@ const reviewsCount = Number(process.env.REVIEWS_COUNT || 5);
 const filterReviewsBy = process.env.FILTER_REVIEWS_BY || "all";
 const timeout = Number(process.env.PUPPETEER_TIMEOUT || 60000); // Default 60s
 
+const validateResult = (result, { expectDescription = true, expectReviews = true } = {}) => {
+  const requiredKeys = [
+    "title",
+    "productId",
+    "images",
+    "variants",
+    "shipping",
+  ];
+
+  for (const key of requiredKeys) {
+    if (result?.[key] == null) {
+      throw new Error(`Missing required key: ${key}`);
+    }
+  }
+
+  if (result.description === undefined) {
+    throw new Error("Missing required key: description (should be null or string)");
+  }
+
+  if (result.reviews === undefined) {
+    throw new Error("Missing required key: reviews (should be array)");
+  }
+
+  if (!Array.isArray(result.images) || result.images.length === 0) {
+    throw new Error("Expected at least one image");
+  }
+
+  if (expectDescription && result.description === null) {
+    console.warn("  Warning: description is null (may be expected for some products)");
+  }
+
+  if (expectReviews && result.reviews.length === 0) {
+    console.warn("  Warning: no reviews returned (may be expected for some products)");
+  }
+};
+
+// --- Normal scrape ---
+console.log("1/2 Normal scrape...");
 const result = await scrape(productId, {
   reviewsCount,
   filterReviewsBy,
-  timeout, // Page navigation timeout
+  timeout,
 });
+validateResult(result);
+console.log(`  OK: ${result.title} (${result.productId})`);
+console.log(`  description: ${result.description ? "present" : "null"}`);
+console.log(`  reviews: ${result.reviews.length}`);
 
-// Required keys - description can be null if not available
-const requiredKeys = [
-  "title",
-  "productId",
-  "images",
-  "reviews",
-  "variants",
-  "shipping",
-];
+// --- fastMode scrape ---
+console.log("2/2 fastMode scrape...");
+const fastResult = await scrape(productId, {
+  fastMode: true,
+  timeout,
+});
+validateResult(fastResult, { expectDescription: false, expectReviews: false });
 
-for (const key of requiredKeys) {
-  if (result?.[key] == null) {
-    throw new Error(`Missing required key: ${key}`);
-  }
+if (fastResult.description !== null) {
+  throw new Error("fastMode should return null description");
 }
-
-// Description is optional - may not always be available
-if (result.description === undefined) {
-  throw new Error("Missing required key: description (should be null or string)");
+if (fastResult.reviews.length !== 0) {
+  throw new Error("fastMode should return empty reviews");
 }
-
-if (!Array.isArray(result.images) || result.images.length === 0) {
-  throw new Error("Expected at least one image");
+if (fastResult.title !== result.title) {
+  throw new Error("fastMode should return same title as normal scrape");
 }
+console.log(`  OK: ${fastResult.title} (fastMode)`);
+console.log(`  description: null (expected)`);
+console.log(`  reviews: 0 (expected)`);
 
-console.log(`Smoke OK: ${result.title} (${result.productId})`);
+console.log("\nAll smoke tests passed.");

--- a/src/aliexpressProductScraper.js
+++ b/src/aliexpressProductScraper.js
@@ -12,7 +12,7 @@ puppeteer.use(StealthPlugin());
 
 const AliexpressProductScraper = async (
   id,
-  { reviewsCount = 20, filterReviewsBy = "all", puppeteerOptions = {}, timeout = 60000 } = {}
+  { reviewsCount = 20, filterReviewsBy = "all", puppeteerOptions = {}, timeout = 60000, fastMode = false } = {}
 ) => {
   if (!id) {
     throw new Error("Please provide a valid product id");
@@ -27,6 +27,19 @@ const AliexpressProductScraper = async (
       ...(puppeteerOptions || {}),
     });
     const page = await browser.newPage();
+
+    // Block heavy resources in fast mode to speed up page load
+    if (fastMode) {
+      await page.setRequestInterception(true);
+      page.on('request', (req) => {
+        const resourceType = req.resourceType();
+        if (['image', 'font', 'stylesheet'].includes(resourceType)) {
+          req.abort();
+        } else {
+          req.continue();
+        }
+      });
+    }
 
     // Set up response interception to capture the product data API
     // AliExpress uses CSR (Client-Side Rendering) and loads data via mtop API
@@ -98,7 +111,7 @@ const AliexpressProductScraper = async (
     /** Scrape the description page for the product using the description url */
     const descriptionUrl = data?.productDescComponent?.descriptionUrl;
     let descriptionDataPromise = null;
-    if (descriptionUrl) {
+    if (!fastMode && descriptionUrl) {
       descriptionDataPromise = page.goto(descriptionUrl).then(async () => {
         const descriptionPageHtml = await page.content();
         const $ = cheerio.load(descriptionPageHtml);
@@ -106,12 +119,14 @@ const AliexpressProductScraper = async (
       });
     }
 
-    const reviewsPromise = GetReviews({
-      productId: id,
-      limit: REVIEWS_COUNT,
-      total: data.feedbackComponent?.totalValidNum || 0,
-      filterReviewsBy,
-    });
+    const reviewsPromise = fastMode
+      ? Promise.resolve([])
+      : GetReviews({
+        productId: id,
+        limit: REVIEWS_COUNT,
+        total: data.feedbackComponent?.totalValidNum || 0,
+        filterReviewsBy,
+      });
 
     const [descriptionData, reviews] = await Promise.all([
       descriptionDataPromise,

--- a/tests/unit/fastMode.test.js
+++ b/tests/unit/fastMode.test.js
@@ -1,71 +1,146 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { buildProductJson } from "../../src/transform.js";
 
-const minimalData = {
-  productInfoComponent: { subject: "Test Product", categoryId: 1, id: 42 },
+const fakeProductData = {
+  productInfoComponent: { subject: "Test Product", categoryId: 1, id: 123 },
   inventoryComponent: { totalQuantity: 10, totalAvailQuantity: 5 },
-  tradeComponent: { formatTradeCount: "100" },
-  sellerComponent: { storeName: "Test Store", storeLogo: null, companyId: 1, storeNum: 2, topRatedSeller: false, payPalAccount: false },
-  storeFeedbackComponent: { sellerPositiveNum: 50, sellerPositiveRate: "96" },
-  feedbackComponent: { evarageStar: "4.5", totalValidNum: 20, fiveStarNum: 10, fourStarNum: 5, threeStarNum: 3, twoStarNum: 1, oneStarNum: 1 },
-  imageComponent: { imagePathList: [] },
+  tradeComponent: { formatTradeCount: "50" },
+  sellerComponent: { storeName: "Store", storeLogo: "", companyId: 1, storeNum: 1 },
+  storeFeedbackComponent: { sellerPositiveNum: 10, sellerPositiveRate: "95" },
+  feedbackComponent: { evarageStar: "4.5", totalValidNum: 100 },
+  imageComponent: { imagePathList: ["img.jpg"] },
   skuComponent: { productSKUPropertyList: [] },
   priceComponent: { skuPriceList: [], origPrice: {}, discountPrice: {} },
   productPropComponent: { props: [] },
   currencyComponent: {},
   webGeneralFreightCalculateComponent: { originalLayoutResultList: [] },
+  productDescComponent: { descriptionUrl: "https://desc.aliexpress.com/desc.html" },
 };
 
-test("fastMode contract: null description and empty reviews produce valid output", () => {
-  const result = buildProductJson({
-    data: minimalData,
-    descriptionData: null,
-    reviews: [],
+test("fastMode integration", async (t) => {
+  let interceptEnabled = false;
+  const navigatedUrls = [];
+  let fetchCallCount = 0;
+
+  const makePage = () => {
+    return {
+      on: () => {},
+      goto: async (url) => {
+        navigatedUrls.push(url);
+      },
+      evaluate: async () => fakeProductData,
+      setRequestInterception: async (val) => {
+        interceptEnabled = val;
+      },
+      content: async () => "<html><body><p>description</p></body></html>",
+    };
+  };
+
+  t.mock.module("puppeteer-extra", {
+    defaultExport: {
+      use: () => {},
+      launch: async () => ({
+        newPage: async () => makePage(),
+        close: async () => {},
+      }),
+    },
   });
 
-  assert.equal(result.description, null);
-  assert.deepStrictEqual(result.reviews, []);
-  assert.equal(typeof result.quantity, "object");
-  assert.equal(typeof result.storeInfo, "object");
-});
-
-test("fastMode contract: description is null when skipped", () => {
-  const result = buildProductJson({
-    data: minimalData,
-    descriptionData: null,
-    reviews: [],
+  t.mock.module("puppeteer-extra-plugin-stealth", {
+    defaultExport: () => ({}),
   });
 
-  assert.equal(result.description, null);
-});
-
-test("fastMode contract: reviews are empty array when skipped", () => {
-  const result = buildProductJson({
-    data: minimalData,
-    descriptionData: null,
-    reviews: [],
+  t.mock.module("node-fetch", {
+    defaultExport: async () => {
+      fetchCallCount++;
+      return {
+        ok: true,
+        json: async () => ({ data: { evaViewList: [] } }),
+      };
+    },
   });
 
-  assert.ok(Array.isArray(result.reviews));
-  assert.equal(result.reviews.length, 0);
-});
-
-test("fastMode contract: all other product fields still populated", () => {
-  const result = buildProductJson({
-    data: minimalData,
-    descriptionData: null,
-    reviews: [],
+  t.mock.module("cheerio", {
+    namedExports: {
+      load: () => () => ({ html: () => "<p>mocked description</p>" }),
+    },
   });
 
-  assert.equal(result.title, "Test Product");
-  assert.equal(result.productId, 42);
-  assert.equal(typeof result.quantity, "object");
-  assert.ok("total" in result.quantity);
-  assert.ok("available" in result.quantity);
-  assert.equal(typeof result.storeInfo, "object");
-  assert.ok("name" in result.storeInfo);
-  assert.equal(typeof result.ratings, "object");
-  assert.ok(Array.isArray(result.images));
-  assert.ok(Array.isArray(result.specs));
+  const { default: scrape } = await import("../../src/aliexpressProductScraper.js");
+
+  await t.test("fastMode=true: enables request interception", async () => {
+    interceptEnabled = false;
+    navigatedUrls.length = 0;
+    fetchCallCount = 0;
+
+    await scrape("123", { fastMode: true });
+
+    assert.equal(interceptEnabled, true, "should call setRequestInterception(true)");
+  });
+
+  await t.test("fastMode=true: only navigates to product page, NOT description", async () => {
+    interceptEnabled = false;
+    navigatedUrls.length = 0;
+    fetchCallCount = 0;
+
+    await scrape("123", { fastMode: true });
+
+    assert.equal(navigatedUrls.length, 1, "should navigate once (product page only)");
+    assert.ok(navigatedUrls[0].includes("/item/123.html"));
+  });
+
+  await t.test("fastMode=true: does NOT call fetch for reviews", async () => {
+    interceptEnabled = false;
+    navigatedUrls.length = 0;
+    fetchCallCount = 0;
+
+    await scrape("123", { fastMode: true });
+
+    assert.equal(fetchCallCount, 0, "fetch should not be called for reviews");
+  });
+
+  await t.test("fastMode=true: returns null description and empty reviews", async () => {
+    interceptEnabled = false;
+    navigatedUrls.length = 0;
+    fetchCallCount = 0;
+
+    const result = await scrape("123", { fastMode: true });
+
+    assert.equal(result.description, null);
+    assert.deepStrictEqual(result.reviews, []);
+    assert.equal(result.title, "Test Product");
+    assert.equal(result.productId, 123);
+  });
+
+  await t.test("fastMode=false: does NOT enable request interception", async () => {
+    interceptEnabled = false;
+    navigatedUrls.length = 0;
+    fetchCallCount = 0;
+
+    await scrape("456");
+
+    assert.equal(interceptEnabled, false, "should NOT call setRequestInterception");
+  });
+
+  await t.test("fastMode=false: navigates to product AND description pages", async () => {
+    interceptEnabled = false;
+    navigatedUrls.length = 0;
+    fetchCallCount = 0;
+
+    await scrape("456");
+
+    assert.equal(navigatedUrls.length, 2, "should navigate twice (product + description)");
+    assert.ok(navigatedUrls[0].includes("/item/456.html"));
+    assert.ok(navigatedUrls[1].includes("desc.aliexpress.com"));
+  });
+
+  await t.test("fastMode=false: calls fetch for reviews", async () => {
+    interceptEnabled = false;
+    navigatedUrls.length = 0;
+    fetchCallCount = 0;
+
+    await scrape("456");
+
+    assert.ok(fetchCallCount > 0, "fetch should be called for reviews");
+  });
 });

--- a/tests/unit/fastMode.test.js
+++ b/tests/unit/fastMode.test.js
@@ -1,0 +1,71 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildProductJson } from "../../src/transform.js";
+
+const minimalData = {
+  productInfoComponent: { subject: "Test Product", categoryId: 1, id: 42 },
+  inventoryComponent: { totalQuantity: 10, totalAvailQuantity: 5 },
+  tradeComponent: { formatTradeCount: "100" },
+  sellerComponent: { storeName: "Test Store", storeLogo: null, companyId: 1, storeNum: 2, topRatedSeller: false, payPalAccount: false },
+  storeFeedbackComponent: { sellerPositiveNum: 50, sellerPositiveRate: "96" },
+  feedbackComponent: { evarageStar: "4.5", totalValidNum: 20, fiveStarNum: 10, fourStarNum: 5, threeStarNum: 3, twoStarNum: 1, oneStarNum: 1 },
+  imageComponent: { imagePathList: [] },
+  skuComponent: { productSKUPropertyList: [] },
+  priceComponent: { skuPriceList: [], origPrice: {}, discountPrice: {} },
+  productPropComponent: { props: [] },
+  currencyComponent: {},
+  webGeneralFreightCalculateComponent: { originalLayoutResultList: [] },
+};
+
+test("fastMode contract: null description and empty reviews produce valid output", () => {
+  const result = buildProductJson({
+    data: minimalData,
+    descriptionData: null,
+    reviews: [],
+  });
+
+  assert.equal(result.description, null);
+  assert.deepStrictEqual(result.reviews, []);
+  assert.equal(typeof result.quantity, "object");
+  assert.equal(typeof result.storeInfo, "object");
+});
+
+test("fastMode contract: description is null when skipped", () => {
+  const result = buildProductJson({
+    data: minimalData,
+    descriptionData: null,
+    reviews: [],
+  });
+
+  assert.equal(result.description, null);
+});
+
+test("fastMode contract: reviews are empty array when skipped", () => {
+  const result = buildProductJson({
+    data: minimalData,
+    descriptionData: null,
+    reviews: [],
+  });
+
+  assert.ok(Array.isArray(result.reviews));
+  assert.equal(result.reviews.length, 0);
+});
+
+test("fastMode contract: all other product fields still populated", () => {
+  const result = buildProductJson({
+    data: minimalData,
+    descriptionData: null,
+    reviews: [],
+  });
+
+  assert.equal(result.title, "Test Product");
+  assert.equal(result.productId, 42);
+  assert.equal(typeof result.quantity, "object");
+  assert.ok("total" in result.quantity);
+  assert.ok("available" in result.quantity);
+  assert.equal(typeof result.storeInfo, "object");
+  assert.ok("name" in result.storeInfo);
+  assert.equal(typeof result.ratings, "object");
+  assert.ok(Array.isArray(result.images));
+  assert.ok(Array.isArray(result.specs));
+});


### PR DESCRIPTION
## Summary
- Added `fastMode` option to the scraper that when enabled:
  - Skips description page navigation (description returns `null`)
  - Skips review API calls (reviews returns `[]`)
  - Blocks images, fonts, and stylesheets via Puppeteer request interception for faster page load
- Output shape is preserved — all fields present, just description/reviews are empty
- Expected 50-70% speedup for users who only need basic product info

## Usage
```js
const product = await scrape("1005006543210", { fastMode: true });
// product.description === null
// product.reviews === []
```

## Test plan
- [x] `pnpm run lint` passes
- [x] `pnpm run test` passes — 4 new fastMode contract tests + all existing tests
- [ ] Verify CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)