### PR TITLE
feat: add scrapeMany() for batch scraping

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,4 @@
 import AliexpressProductScraper from "./src/aliexpressProductScraper.js";
+import { scrapeMany } from "./src/scrapeMany.js";
 export default AliexpressProductScraper;
+export { scrapeMany };

--- a/scripts/smoke.js
+++ b/scripts/smoke.js
@@ -1,4 +1,5 @@
 import scrape from "../index.js";
+import { scrapeMany } from "../index.js";
 
 if (!process.env.ALIX_SMOKE) {
   console.log("Set ALIX_SMOKE=1 to run the smoke test.");
@@ -11,35 +12,74 @@ const reviewsCount = Number(process.env.REVIEWS_COUNT || 5);
 const filterReviewsBy = process.env.FILTER_REVIEWS_BY || "all";
 const timeout = Number(process.env.PUPPETEER_TIMEOUT || 60000); // Default 60s
 
+const validateResult = (result) => {
+  const requiredKeys = [
+    "title",
+    "productId",
+    "images",
+    "reviews",
+    "variants",
+    "shipping",
+  ];
+
+  for (const key of requiredKeys) {
+    if (result?.[key] == null) {
+      throw new Error(`Missing required key: ${key}`);
+    }
+  }
+
+  if (result.description === undefined) {
+    throw new Error("Missing required key: description (should be null or string)");
+  }
+
+  if (!Array.isArray(result.images) || result.images.length === 0) {
+    throw new Error("Expected at least one image");
+  }
+};
+
+// --- Single scrape ---
+console.log("1/2 Single scrape...");
 const result = await scrape(productId, {
   reviewsCount,
   filterReviewsBy,
-  timeout, // Page navigation timeout
+  timeout,
+});
+validateResult(result);
+console.log(`  OK: ${result.title} (${result.productId})`);
+
+// --- Batch scrape with scrapeMany ---
+console.log("2/2 scrapeMany with 1 product...");
+const progressEvents = [];
+const batchResults = await scrapeMany([productId], {
+  concurrency: 1,
+  retries: 1,
+  timeout,
+  reviewsCount,
+  filterReviewsBy,
+  onProgress: (event) => progressEvents.push(event),
 });
 
-// Required keys - description can be null if not available
-const requiredKeys = [
-  "title",
-  "productId",
-  "images",
-  "reviews",
-  "variants",
-  "shipping",
-];
-
-for (const key of requiredKeys) {
-  if (result?.[key] == null) {
-    throw new Error(`Missing required key: ${key}`);
-  }
+if (batchResults.length !== 1) {
+  throw new Error(`Expected 1 result, got ${batchResults.length}`);
 }
 
-// Description is optional - may not always be available
-if (result.description === undefined) {
-  throw new Error("Missing required key: description (should be null or string)");
+const batchItem = batchResults[0];
+if (batchItem.error) {
+  throw new Error(`scrapeMany failed: ${batchItem.error.message}`);
+}
+if (batchItem.productId !== productId) {
+  throw new Error(`Wrong productId: ${batchItem.productId}`);
+}
+validateResult(batchItem.data);
+
+if (progressEvents.length !== 1) {
+  throw new Error(`Expected 1 progress event, got ${progressEvents.length}`);
+}
+if (progressEvents[0].completed !== 1 || progressEvents[0].total !== 1) {
+  throw new Error("Progress event has wrong counts");
 }
 
-if (!Array.isArray(result.images) || result.images.length === 0) {
-  throw new Error("Expected at least one image");
-}
+console.log(`  OK: ${batchItem.data.title} (via scrapeMany)`);
+console.log(`  onProgress fired: ${progressEvents.length} event(s)`);
 
-console.log(`Smoke OK: ${result.title} (${result.productId})`);
+console.log("\nAll smoke tests passed.");

--- a/src/scrapeMany.js
+++ b/src/scrapeMany.js
@@ -1,0 +1,97 @@
+import AliexpressProductScraper from "./aliexpressProductScraper.js";
+
+/**
+ * Core batch scraping orchestration. Accepts a custom scrapeFn for testability.
+ *
+ * @param {string[]} ids - Array of product IDs to scrape
+ * @param {object} options - Options for batch scraping
+ * @param {number} [options.concurrency=2] - Max number of concurrent scrape operations
+ * @param {number} [options.retries=1] - Number of retry attempts on failure
+ * @param {number} [options.timeout=60000] - Timeout per scrape in ms
+ * @param {Function|null} [options.onProgress=null] - Progress callback
+ * @param {Function} [scrapeFn=AliexpressProductScraper] - Scraper function to use
+ * @returns {Promise<Array<{productId: string, data: object|null, error: Error|null}>>}
+ */
+const batchScrape = async (ids, options = {}, scrapeFn = AliexpressProductScraper) => {
+  const {
+    concurrency = 2,
+    retries = 1,
+    timeout = 60000,
+    onProgress = null,
+    ...scraperOptions
+  } = options;
+
+  if (!ids || ids.length === 0) {
+    return [];
+  }
+
+  const results = [];
+  let completed = 0;
+  const total = ids.length;
+
+  const queue = [...ids];
+
+  const processItem = async () => {
+    while (queue.length > 0) {
+      const productId = queue.shift();
+      let lastError = null;
+      let data = null;
+
+      for (let attempt = 0; attempt <= retries; attempt++) {
+        try {
+          data = await scrapeFn(productId, {
+            ...scraperOptions,
+            timeout,
+          });
+          break;
+        } catch (error) {
+          lastError = error;
+        }
+      }
+
+      completed++;
+      const result = data
+        ? { productId, data, error: null }
+        : { productId, data: null, error: lastError };
+      results.push(result);
+
+      if (onProgress) {
+        onProgress({
+          completed,
+          total,
+          productId,
+          success: data !== null,
+        });
+      }
+    }
+  };
+
+  // Launch concurrent workers
+  const workers = [];
+  for (let i = 0; i < Math.min(concurrency, ids.length); i++) {
+    workers.push(processItem());
+  }
+
+  await Promise.all(workers);
+  return results;
+};
+
+/**
+ * Scrape multiple AliExpress products in batch with concurrency control.
+ *
+ * @param {string[]} ids - Array of product IDs to scrape
+ * @param {object} [options={}] - Options for batch scraping
+ * @param {number} [options.concurrency=2] - Max number of concurrent scrape operations
+ * @param {number} [options.retries=1] - Number of retry attempts on failure
+ * @param {number} [options.timeout=60000] - Timeout per scrape in ms
+ * @param {Function|null} [options.onProgress=null] - Progress callback called after each item
+ * @param {number} [options.reviewsCount] - Number of reviews to fetch per product
+ * @param {string} [options.filterReviewsBy] - Filter reviews by this value
+ * @param {object} [options.puppeteerOptions] - Extra puppeteer launch options
+ * @returns {Promise<Array<{productId: string, data: object|null, error: Error|null}>>}
+ */
+const scrapeMany = async (ids, options = {}) => {
+  return batchScrape(ids, options);
+};
+
+export { scrapeMany, batchScrape };

--- a/tests/unit/scrapeMany.test.js
+++ b/tests/unit/scrapeMany.test.js
@@ -1,0 +1,163 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { batchScrape } from "../../src/scrapeMany.js";
+
+test("batchScrape returns empty array for empty input", async () => {
+  const results = await batchScrape([], {});
+  assert.deepStrictEqual(results, []);
+});
+
+test("batchScrape scrapes all items", async () => {
+  const mockScrape = async (id) => ({ title: `Product ${id}` });
+
+  const results = await batchScrape(["1", "2", "3"], {}, mockScrape);
+  assert.equal(results.length, 3);
+
+  const ids = results.map((r) => r.productId).sort();
+  assert.deepStrictEqual(ids, ["1", "2", "3"]);
+});
+
+test("batchScrape respects concurrency limit", async () => {
+  let concurrent = 0;
+  let maxConcurrent = 0;
+
+  const mockScrape = async (id) => {
+    concurrent++;
+    maxConcurrent = Math.max(maxConcurrent, concurrent);
+    await new Promise((r) => setTimeout(r, 50));
+    concurrent--;
+    return { title: `Product ${id}` };
+  };
+
+  const results = await batchScrape(
+    ["1", "2", "3", "4"],
+    { concurrency: 2 },
+    mockScrape
+  );
+
+  assert.equal(results.length, 4);
+  assert.ok(
+    maxConcurrent <= 2,
+    `Max concurrent was ${maxConcurrent}, expected <= 2`
+  );
+});
+
+test("batchScrape sets data=null and error on failed items", async () => {
+  const mockScrape = async (_id) => {
+    throw new Error("scrape failed");
+  };
+
+  const results = await batchScrape(["42"], { retries: 0 }, mockScrape);
+  assert.equal(results.length, 1);
+  assert.equal(results[0].productId, "42");
+  assert.equal(results[0].data, null);
+  assert.ok(results[0].error instanceof Error);
+  assert.equal(results[0].error.message, "scrape failed");
+});
+
+test("batchScrape sets data and error=null on successful items", async () => {
+  const mockScrape = async (id) => ({ title: `Product ${id}` });
+
+  const results = await batchScrape(["7"], {}, mockScrape);
+  assert.equal(results.length, 1);
+  assert.equal(results[0].productId, "7");
+  assert.deepStrictEqual(results[0].data, { title: "Product 7" });
+  assert.equal(results[0].error, null);
+});
+
+test("batchScrape retries on failure and succeeds", async () => {
+  let callCount = 0;
+
+  const mockScrape = async (id) => {
+    callCount++;
+    if (callCount === 1) {
+      throw new Error("first attempt fails");
+    }
+    return { title: `Product ${id}` };
+  };
+
+  const results = await batchScrape(["99"], { retries: 1 }, mockScrape);
+  assert.equal(results.length, 1);
+  assert.equal(results[0].productId, "99");
+  assert.deepStrictEqual(results[0].data, { title: "Product 99" });
+  assert.equal(results[0].error, null);
+  assert.equal(callCount, 2, "Should have been called twice (1 fail + 1 success)");
+});
+
+test("batchScrape exhausts all retries and returns error", async () => {
+  let callCount = 0;
+
+  const mockScrape = async (_id) => {
+    callCount++;
+    throw new Error(`attempt ${callCount} failed`);
+  };
+
+  const results = await batchScrape(["55"], { retries: 2 }, mockScrape);
+  assert.equal(results.length, 1);
+  assert.equal(results[0].data, null);
+  assert.ok(results[0].error instanceof Error);
+  // retries=2 means up to 3 total attempts (attempt 0, 1, 2)
+  assert.equal(callCount, 3, "Should have tried 3 times (initial + 2 retries)");
+});
+
+test("batchScrape calls onProgress for each item", async () => {
+  const progressEvents = [];
+
+  const mockScrape = async (id) => ({ title: `Product ${id}` });
+
+  await batchScrape(
+    ["a", "b", "c"],
+    {
+      concurrency: 1,
+      onProgress: (event) => progressEvents.push(event),
+    },
+    mockScrape
+  );
+
+  assert.equal(progressEvents.length, 3);
+
+  // With concurrency=1 and sequential processing, completed counts should be 1, 2, 3
+  const completedCounts = progressEvents.map((e) => e.completed).sort((a, b) => a - b);
+  assert.deepStrictEqual(completedCounts, [1, 2, 3]);
+
+  progressEvents.forEach((event) => {
+    assert.equal(event.total, 3);
+    assert.equal(event.success, true);
+    assert.ok(["a", "b", "c"].includes(event.productId));
+  });
+});
+
+test("batchScrape onProgress reports failure correctly", async () => {
+  const progressEvents = [];
+
+  const mockScrape = async (_id) => {
+    throw new Error("fail");
+  };
+
+  await batchScrape(
+    ["x"],
+    {
+      retries: 0,
+      onProgress: (event) => progressEvents.push(event),
+    },
+    mockScrape
+  );
+
+  assert.equal(progressEvents.length, 1);
+  assert.equal(progressEvents[0].success, false);
+  assert.equal(progressEvents[0].productId, "x");
+});
+
+test("batchScrape includes correct productId for each result", async () => {
+  const ids = ["100", "200", "300"];
+  const mockScrape = async (id) => ({ title: `Product ${id}` });
+
+  const results = await batchScrape(ids, {}, mockScrape);
+
+  // Each result's productId should match the id we passed
+  results.forEach((result) => {
+    assert.ok(ids.includes(result.productId));
+    assert.deepStrictEqual(result.data, { title: `Product ${result.productId}` });
+  });
+});


### PR DESCRIPTION
## Summary
- Added `scrapeMany()` function for batch scraping multiple products
- Features:
  - **Concurrency control** — configurable max parallel scrapes (default: 2)
  - **Retries** — per-item retry on failure (default: 1)
  - **Timeout** — per-item timeout passed to the scraper
  - **Progress callback** — `onProgress({ completed, total, productId, success })`
  - **Error isolation** — one item's failure doesn't abort the batch
- Testable design: core `batchScrape()` accepts injectable `scrapeFn` for unit testing
- Updated `index.js` to export `scrapeMany` as a named export

## Usage
```js
import scrape, { scrapeMany } from "aliexpress-product-scraper";

const results = await scrapeMany(["id1", "id2", "id3"], {
  concurrency: 3,
  retries: 2,
  onProgress: ({ completed, total }) => console.log(`${completed}/${total}`),
});
// results: [{ productId, data, error }, ...]
```

## Test plan
- [x] `pnpm run lint` passes
- [x] `pnpm run test` passes — 10 new scrapeMany tests covering concurrency, retries, progress, error isolation
- [ ] Verify CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)