### PR TITLE
feat: accept product URL as input

### DIFF
--- a/docs/FEATURE_PROPOSALS.md
+++ b/docs/FEATURE_PROPOSALS.md
@@ -1,0 +1,159 @@
+# Feature Proposals
+
+Detailed specs for the top 3 features on the roadmap. See [PLAN.md](./PLAN.md) for the full milestone overview.
+
+---
+
+## 1. Accept Product URL (not just ID)
+
+**Phase:** 2 (codex/ux-perf)
+**Effort:** Low | **Impact:** High
+
+### Problem
+Users typically copy a full AliExpress URL from their browser. Requiring them to manually extract the numeric product ID is friction-heavy and error-prone.
+
+### Proposed API
+
+```js
+import scrape from "aliexpress-product-scraper";
+
+// Existing — still works
+const product = await scrape("1005006543210");
+
+// New — pass a full URL
+const product = await scrape("https://www.aliexpress.com/item/1005006543210.html");
+```
+
+### Supported URL formats
+
+| Pattern | Example |
+|---|---|
+| `aliexpress.com/item/<id>.html` | `https://www.aliexpress.com/item/1005006543210.html` |
+| `aliexpress.us/item/<id>.html` | `https://aliexpress.us/item/1005006543210.html` |
+| Mobile | `https://m.aliexpress.com/item/1005006543210.html` |
+| With query params | `https://www.aliexpress.com/item/1005006543210.html?spm=abc` |
+
+### Implementation notes
+- Parse the input: if it contains `/item/`, extract the numeric ID via regex.
+- If the input is already numeric (or numeric string), use it directly.
+- Throw a clear error for unrecognized formats.
+
+### Acceptance criteria
+- [ ] `scrape(url)` produces identical output to `scrape(id)` for the same product
+- [ ] All supported URL formats resolve correctly
+- [ ] Invalid URLs throw a descriptive error
+- [ ] Existing numeric ID usage is unaffected (backward compatible)
+- [ ] Unit tests cover URL parsing logic
+
+---
+
+## 2. `fastMode` Option
+
+**Phase:** 2 (codex/ux-perf)
+**Effort:** Medium | **Impact:** High
+
+### Problem
+Many users (especially dropshippers doing quick lookups) only need basic product info — title, price, variants, images. Fetching the full description page and reviews API adds significant time.
+
+### Proposed API
+
+```js
+import scrape from "aliexpress-product-scraper";
+
+const product = await scrape("1005006543210", { fastMode: true });
+
+// product.description === null
+// product.reviews === []
+```
+
+### What changes in fastMode
+
+| Field | Normal | fastMode |
+|---|---|---|
+| `title`, `productId`, `categoryId` | Populated | Populated |
+| `quantity`, `orders` | Populated | Populated |
+| `storeInfo`, `ratings` | Populated | Populated |
+| `images`, `variants`, `specs` | Populated | Populated |
+| `originalPrice`, `salePrice` | Populated | Populated |
+| `currencyInfo`, `shipping` | Populated | Populated |
+| `description` | HTML string | `null` |
+| `reviews` | Array of reviews | `[]` |
+
+### Performance optimizations
+- Skip navigation to description iframe/page
+- Skip review API calls (all pagination)
+- Block heavy resources in Puppeteer (images, fonts, stylesheets) via `page.setRequestInterception`
+- Expected speedup: 50–70%
+
+### Acceptance criteria
+- [ ] `fastMode: true` skips description and review fetching
+- [ ] Output shape is identical (description is `null`, reviews is `[]`)
+- [ ] Resource blocking reduces page load time measurably
+- [ ] Default behavior (`fastMode` unset or `false`) is unchanged
+- [ ] Unit tests verify field presence/absence in fastMode
+
+---
+
+## 3. Batch Scraping with `scrapeMany()`
+
+**Phase:** 3 (codex/feature/batch)
+**Effort:** High | **Impact:** High
+
+### Problem
+Dropshipping users need to scrape dozens or hundreds of products. Calling `scrape()` sequentially is slow, and naively parallelizing it crashes the browser or triggers rate limiting.
+
+### Proposed API
+
+#### Callback style
+
+```js
+import { scrapeMany } from "aliexpress-product-scraper";
+
+const results = await scrapeMany(
+  ["1005006543210", "1005006543211", "1005006543212"],
+  {
+    concurrency: 3,        // max parallel browser tabs (default: 2)
+    retries: 2,            // retries per item on failure (default: 1)
+    timeout: 30000,        // per-item timeout in ms (default: 60000)
+    fastMode: false,       // applies to all items
+    onProgress: ({ completed, total, productId, success }) => {
+      console.log(`${completed}/${total} done`);
+    },
+  }
+);
+
+// results: Array<{ productId, data, error }>
+```
+
+#### Async iterator style
+
+```js
+import { scrapeMany } from "aliexpress-product-scraper";
+
+for await (const result of scrapeMany(ids, { concurrency: 3 })) {
+  if (result.error) {
+    console.error(`Failed: ${result.productId}`, result.error);
+  } else {
+    console.log(`Got: ${result.data.title}`);
+  }
+}
+```
+
+### Design decisions
+- **Browser reuse:** open one browser, use multiple tabs (pages) for concurrency
+- **Concurrency control:** limit active tabs to `concurrency` value
+- **Retries:** per-item retry with exponential backoff
+- **Timeout:** per-item timeout; does not affect other items
+- **Error isolation:** one item's failure does not abort the batch
+- **Return format:** each result includes `{ productId, data, error }` so callers can handle partial failures
+
+### Acceptance criteria
+- [ ] `scrapeMany()` scrapes multiple products concurrently
+- [ ] Concurrency is respected (never exceeds `concurrency` tabs)
+- [ ] Failed items are retried up to `retries` times
+- [ ] Per-item timeout terminates slow scrapes without affecting others
+- [ ] `onProgress` callback fires after each item completes
+- [ ] Async iterator yields results as they complete
+- [ ] Browser is reused across all items and closed after completion
+- [ ] Existing `scrape()` API is unchanged
+- [ ] Integration test with fixtures verifies batch orchestration logic

--- a/scripts/smoke.js
+++ b/scripts/smoke.js
@@ -7,39 +7,65 @@ if (!process.env.ALIX_SMOKE) {
 
 // Default to a known working product (Wireless Keyboard - verified Jan 2025)
 const productId = process.env.ALIX_PRODUCT_ID || "1005007429636284";
+const productUrl = `https://www.aliexpress.com/item/${productId}.html`;
 const reviewsCount = Number(process.env.REVIEWS_COUNT || 5);
 const filterReviewsBy = process.env.FILTER_REVIEWS_BY || "all";
 const timeout = Number(process.env.PUPPETEER_TIMEOUT || 60000); // Default 60s
 
-const result = await scrape(productId, {
+const validateResult = (result) => {
+  const requiredKeys = [
+    "title",
+    "productId",
+    "images",
+    "reviews",
+    "variants",
+    "shipping",
+  ];
+
+  for (const key of requiredKeys) {
+    if (result?.[key] == null) {
+      throw new Error(`Missing required key: ${key}`);
+    }
+  }
+
+  if (result.description === undefined) {
+    throw new Error("Missing required key: description (should be null or string)");
+  }
+
+  if (!Array.isArray(result.images) || result.images.length === 0) {
+    throw new Error("Expected at least one image");
+  }
+};
+
+// --- Scrape by ID ---
+console.log("1/2 Scrape by product ID...");
+const resultById = await scrape(productId, {
   reviewsCount,
   filterReviewsBy,
-  timeout, // Page navigation timeout
+  timeout,
 });
+validateResult(resultById);
+console.log(`  OK: ${resultById.title} (${resultById.productId})`);
 
-// Required keys - description can be null if not available
-const requiredKeys = [
-  "title",
-  "productId",
-  "images",
-  "reviews",
-  "variants",
-  "shipping",
-];
+// --- Scrape by URL ---
+console.log("2/2 Scrape by product URL...");
+const resultByUrl = await scrape(productUrl, {
+  reviewsCount,
+  filterReviewsBy,
+  timeout,
+});
+validateResult(resultByUrl);
 
-for (const key of requiredKeys) {
-  if (result?.[key] == null) {
-    throw new Error(`Missing required key: ${key}`);
-  }
+if (resultByUrl.productId !== resultById.productId) {
+  throw new Error(
+    `URL scrape returned different productId: ${resultByUrl.productId} vs ${resultById.productId}`
+  );
 }
-
-// Description is optional - may not always be available
-if (result.description === undefined) {
-  throw new Error("Missing required key: description (should be null or string)");
+if (resultByUrl.title !== resultById.title) {
+  throw new Error(
+    `URL scrape returned different title: "${resultByUrl.title}" vs "${resultById.title}"`
+  );
 }
+console.log(`  OK: ${resultByUrl.title} (via URL)`);
 
-if (!Array.isArray(result.images) || result.images.length === 0) {
-  throw new Error("Expected at least one image");
-}
-
-console.log(`Smoke OK: ${result.title} (${result.productId})`);
+console.log("\nAll smoke tests passed.");

--- a/src/aliexpressProductScraper.js
+++ b/src/aliexpressProductScraper.js
@@ -5,6 +5,7 @@ import * as cheerio from "cheerio";
 import { get as GetReviews } from "./reviews.js";
 import { parseJsonp, extractDataFromApiResponse } from "./parsers.js";
 import { buildProductJson } from "./transform.js";
+import { parseProductId } from "./parseProductId.js";
 
 // Use stealth plugin to avoid bot detection
 puppeteer.use(StealthPlugin());
@@ -15,8 +16,10 @@ const AliexpressProductScraper = async (
   { reviewsCount = 20, filterReviewsBy = "all", puppeteerOptions = {}, timeout = 60000 } = {}
 ) => {
   if (!id) {
-    throw new Error("Please provide a valid product id");
+    throw new Error("Please provide a valid product ID or AliExpress URL");
   }
+
+  const productId = parseProductId(id);
 
   let browser;
 
@@ -51,7 +54,7 @@ const AliexpressProductScraper = async (
     });
 
     /** Scrape the aliexpress product page for details */
-    await page.goto(`https://www.aliexpress.com/item/${id}.html`, {
+    await page.goto(`https://www.aliexpress.com/item/${productId}.html`, {
       waitUntil: "networkidle2", // Use networkidle2 for CSR pages
       timeout: timeout,
     });
@@ -89,7 +92,7 @@ const AliexpressProductScraper = async (
 
     if (!data) {
       throw new Error(
-        `Failed to extract product data for product ID: ${id}. ` +
+        `Failed to extract product data for product ID: ${productId}. ` +
         `This may indicate: (1) The product ID is invalid, (2) AliExpress page structure has changed, ` +
         `(3) The page didn't load completely, or (4) Anti-bot measures are blocking access.`
       );
@@ -107,7 +110,7 @@ const AliexpressProductScraper = async (
     }
 
     const reviewsPromise = GetReviews({
-      productId: id,
+      productId: productId,
       limit: REVIEWS_COUNT,
       total: data.feedbackComponent?.totalValidNum || 0,
       filterReviewsBy,

--- a/src/parseProductId.js
+++ b/src/parseProductId.js
@@ -1,0 +1,37 @@
+/**
+ * Parses a product ID or AliExpress product URL and returns the numeric product ID as a string.
+ *
+ * Accepts:
+ *  - A numeric string or number (returned as-is, as a string)
+ *  - A full AliExpress URL containing /item/<id>.html
+ *    Supported hosts: aliexpress.com, aliexpress.us, m.aliexpress.com
+ *
+ * Throws a descriptive error for unrecognized inputs.
+ */
+const parseProductId = (input) => {
+  if (input === null || input === undefined || input === "") {
+    throw new Error("Please provide a valid product ID or AliExpress URL");
+  }
+
+  const str = String(input).trim();
+
+  // If the input is purely numeric, return it directly as a string
+  if (/^\d+$/.test(str)) {
+    return str;
+  }
+
+  // Try to extract the product ID from an AliExpress URL
+  // Matches paths like /item/1005006543210.html (with optional query params / hash)
+  const match = str.match(/\/item\/(\d+)\.html/);
+  if (match) {
+    return match[1];
+  }
+
+  throw new Error(
+    `Unrecognized product input: "${str}". ` +
+    "Please provide a numeric product ID or a valid AliExpress product URL " +
+    "(e.g. https://www.aliexpress.com/item/1005006543210.html)"
+  );
+};
+
+export { parseProductId };

--- a/tests/unit/parseProductId.test.js
+++ b/tests/unit/parseProductId.test.js
@@ -1,0 +1,78 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { parseProductId } from "../../src/parseProductId.js";
+
+// --- Numeric inputs ---
+
+test("numeric string passes through as-is", () => {
+  assert.equal(parseProductId("1005006543210"), "1005006543210");
+});
+
+test("number (integer) is converted to string", () => {
+  assert.equal(parseProductId(1005006543210), "1005006543210");
+});
+
+// --- URL inputs ---
+
+test("standard aliexpress.com URL extracts product ID", () => {
+  assert.equal(
+    parseProductId("https://www.aliexpress.com/item/1005006543210.html"),
+    "1005006543210"
+  );
+});
+
+test("aliexpress.us URL extracts product ID", () => {
+  assert.equal(
+    parseProductId("https://aliexpress.us/item/1005006543210.html"),
+    "1005006543210"
+  );
+});
+
+test("mobile aliexpress URL extracts product ID", () => {
+  assert.equal(
+    parseProductId("https://m.aliexpress.com/item/1005006543210.html"),
+    "1005006543210"
+  );
+});
+
+test("URL with query params extracts product ID", () => {
+  assert.equal(
+    parseProductId("https://www.aliexpress.com/item/1005006543210.html?spm=abc&algo=xyz"),
+    "1005006543210"
+  );
+});
+
+// --- Invalid inputs ---
+
+test("non-AliExpress URL throws descriptive error", () => {
+  assert.throws(
+    () => parseProductId("https://google.com"),
+    (err) => {
+      assert.ok(err instanceof Error);
+      assert.ok(err.message.includes("Unrecognized product input"));
+      return true;
+    }
+  );
+});
+
+test("empty string throws error", () => {
+  assert.throws(
+    () => parseProductId(""),
+    (err) => {
+      assert.ok(err instanceof Error);
+      assert.ok(err.message.includes("valid product ID or AliExpress URL"));
+      return true;
+    }
+  );
+});
+
+test("null throws error", () => {
+  assert.throws(
+    () => parseProductId(null),
+    (err) => {
+      assert.ok(err instanceof Error);
+      assert.ok(err.message.includes("valid product ID or AliExpress URL"));
+      return true;
+    }
+  );
+});


### PR DESCRIPTION
## Summary
- Added `src/parseProductId.js` utility that accepts a numeric product ID (string or number) or any AliExpress product URL and returns the extracted numeric ID
- Supported URL formats: `aliexpress.com`, `aliexpress.us`, `m.aliexpress.com`, URLs with query params
- Updated `src/aliexpressProductScraper.js` to normalise input through `parseProductId` before navigating
- Added 9 unit tests covering numeric pass-through, all URL variants, and invalid-input error paths

## Usage
```js
import scrape from "aliexpress-product-scraper";

// Both produce identical results:
await scrape("1005006543210");
await scrape("https://www.aliexpress.com/item/1005006543210.html");
```

## Test plan
- [x] `pnpm run lint` passes
- [x] `pnpm run test` passes — 20 tests (11 existing + 9 new)
- [ ] Verify CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)